### PR TITLE
Fix "implicit conversion of String into Integer" error

### DIFF
--- a/app/services/spree/sofort_service.rb
+++ b/app/services/spree/sofort_service.rb
@@ -124,8 +124,8 @@ module Spree
         response[:redirect_url] = @cancel_url
         response[:transaction] = ""
         response[:error] = I18n.t("sofort.error_from_sofort")+":
-                        #{raw_response.parsed_response["errors"]["error"]["field"]}:
-                        #{raw_response.parsed_response["errors"]["error"]["message"]}"
+                        #{raw_response.parsed_response["errors"]["error"].map{ |h| h["field"]}}:
+                        #{raw_response.parsed_response["errors"]["error"].map{ |h| h["message"]}}"
       else
         response[:redirect_url] = raw_response.parsed_response["new_transaction"]["payment_url"]
         response[:transaction] = raw_response.parsed_response["new_transaction"]["transaction"]


### PR DESCRIPTION
Fix "implicit conversion of String into Integer" error caused by new array format of sofort's error messages. instead, inject all errors in the array to form a combined error message