### PR TITLE
replace render :nothing with head :ok

### DIFF
--- a/app/controllers/spree/sofort_controller.rb
+++ b/app/controllers/spree/sofort_controller.rb
@@ -34,7 +34,7 @@ class Spree::SofortController < Spree::StoreController
 
   def status
     Spree::SofortService.instance.eval_transaction_status_change(params)
-    render nothing: true
+    head :ok
   end
 
   private


### PR DESCRIPTION
This will further improve the Rails 5.1 compatibility by removing the deprecated use of `render nothing: true` by using `head :ok`. See http://edgeguides.rubyonrails.org/5_1_release_notes.html#action-pack-removals