### PR TITLE
complete order before auto capture

### DIFF
--- a/app/controllers/spree/sofort_controller.rb
+++ b/app/controllers/spree/sofort_controller.rb
@@ -19,8 +19,8 @@ class Spree::SofortController < Spree::StoreController
     unless order.complete?  # complete again via browser back or recalling sofort "go" url
       order.finalize!
       order.state = "complete"
-      sofort_payment.capture! if sofort_payment.payment_method.auto_capture?
       order.save!
+      sofort_payment.capture! if sofort_payment.payment_method.auto_capture?
       session[:order_id] = nil
       flash[:success] = I18n.t("sofort.completed_successfully")
     end


### PR DESCRIPTION
At the moment an order will stay in the state `confirm` when auto capture is enabled. As a result the order cannot be shipped.

I assume the call `sofort_payment.capture!` is resetting the before set order state because it is not saved before the `capture!` call.

This change will save the order before the `capture!` method is called.